### PR TITLE
refactor(example): update training examples

### DIFF
--- a/examples/tf-jobs/tf-dist-training-job.yaml
+++ b/examples/tf-jobs/tf-dist-training-job.yaml
@@ -22,6 +22,8 @@ spec:
         - name: tensorflow
           image: cargo.caicloud.io/clever-base/tensorflow:v1.4.0-example
           command: ["python", "/opt/mnist/mnist_replica.py"]
+          args:
+          - "--data_dir=/opt/mnist-data"
           ports:
           - containerPort: 2222
         restartPolicy: OnFailure

--- a/examples/tf-jobs/tf-dist-training-job.yaml
+++ b/examples/tf-jobs/tf-dist-training-job.yaml
@@ -1,9 +1,8 @@
 apiVersion: "kubeflow.caicloud.io/v1alpha1"
 kind: "TFJob"
 metadata:
-  name: "training-job"
+  name: "dist-training-job"
 spec:
-  type: Training
   tfReplicaSpec:
   - replicas: 2
     tfReplicaType: PS
@@ -11,37 +10,18 @@ spec:
       spec:
         containers:
         - name: tensorflow
-          image: cargo.caicloud.io/clever-base/tensorflow:1.4.0
-          command:
-          - "/workdir/tensorflow/launch_training.sh"
-          volumeMounts:
-          - name: workdir
-            mountPath: /workdir
-        volumes:
-        - name: workdir
-          glusterfs:
-            endpoints: <gluster-cluster>
-            path: <gluster_vol_subpath>
-        restartPolicy: OnFailure
+          image: cargo.caicloud.io/clever-base/tensorflow:v1.4.0-example
+          command: ["python", "/opt/mnist/mnist_replica.py"]
+          ports:
+          - containerPort: 2222
   - replicas: 4
     tfReplicaType: Worker
     template:
       spec:
         containers:
         - name: tensorflow
-          image: cargo.caicloud.io/clever-base/tensorflow:1.4.0
-          command:
-          - "/workdir/tensorflow/launch_training.sh"
-          args:
-          - "--data_dir=/workdir/data"
-          - "--train_dir=/workdir/train"
-          - "--model_dir=/workdir/model"
-          volumeMounts:
-          - name: workdir
-            mountPath: /workdir
-        volumes:
-        - name: workdir
-          glusterfs:
-            endpoints: <gluster-cluster>
-            path: <gluster_vol_subpath>
+          image: cargo.caicloud.io/clever-base/tensorflow:v1.4.0-example
+          command: ["python", "/opt/mnist/mnist_replica.py"]
+          ports:
+          - containerPort: 2222
         restartPolicy: OnFailure

--- a/examples/tf-jobs/tf-local-training-job.yaml
+++ b/examples/tf-jobs/tf-local-training-job.yaml
@@ -1,9 +1,8 @@
 apiVersion: "kubeflow.caicloud.io/v1alpha1"
 kind: "TFJob"
 metadata:
-  name: "training-job"
+  name: "local-training-job"
 spec:
-  type: Training
   tfReplicaSpec:
   - replicas: 1
     tfReplicaType: Local
@@ -11,15 +10,6 @@ spec:
       spec:
         containers:
         - name: tensorflow
-          image: cargo.caicloud.io/clever-base/tensorflow:1.4.0
-          command:
-          - "/workdir/tensorflow/launch_training.sh"
-          volumeMounts:
-          - name: workdir
-            mountPath: /workdir
-        volumes:
-        - name: workdir
-          glusterfs:
-            endpoints: <gluster-cluster>
-            path: <gluster_vol_subpath>
+          image: cargo.caicloud.io/clever-base/tensorflow:v1.4.0-example
+          command: ["python", "/opt/mnist/mnist_softmax.py"]
         restartPolicy: OnFailure


### PR DESCRIPTION
We have built `cargo.caicloud.io/clever-base/tensorflow:v1.4.0-example` image locally. The corresponding Dockerfile can be found here https://github.com/caicloud/dockerfile/pull/16 .

If we use the example image, we can get rid of the external dependency.

cc/ @gaocegege-caicloud @zjx-caicloud @ScorpioCPH 